### PR TITLE
sph_types.h: Fix sparc64 inline asm constraints

### DIFF
--- a/c/sph_types.h
+++ b/c/sph_types.h
@@ -1879,7 +1879,7 @@ sph_dec64le(const void *src)
 		sph_u64 tmp;
 
 		__asm__ __volatile__ (
-			"ldxa [%1]0x88,%0" : "=r" (tmp) : "r" (src));
+			"ldxa [%1]0x88,%0" : "=r" (tmp) : "r" (src), "m" (*(const sph_u64 *)src));
 		return tmp;
 /*
  * Not worth it generally.
@@ -1940,7 +1940,7 @@ sph_dec64le_aligned(const void *src)
 #if SPH_SPARCV9_GCC_64 && !SPH_NO_ASM
 	sph_u64 tmp;
 
-	__asm__ __volatile__ ("ldxa [%1]0x88,%0" : "=r" (tmp) : "r" (src));
+	__asm__ __volatile__ ("ldxa [%1]0x88,%0" : "=r" (tmp) : "r" (src), "m" (*(const sph_u64 *)src));
 	return tmp;
 /*
  * Not worth it generally.


### PR DESCRIPTION
This is a start at fixing #1.